### PR TITLE
Mirror of dropbox djinni#365

### DIFF
--- a/src/source/JavaGenerator.scala
+++ b/src/source/JavaGenerator.scala
@@ -180,12 +180,12 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
             }
             w.wl
             w.wl("private native void nativeDestroy(long nativeRef);")
-            w.wl("public void __destroy()").braced {
+            w.wl("public void _djinni_destroy()").braced {
               w.wl("boolean destroyed = this.destroyed.getAndSet(true);")
               w.wl("if (!destroyed) nativeDestroy(this.nativeRef);")
             }
             w.wl("protected void finalize() throws java.lang.Throwable").braced {
-              w.wl("__destroy();")
+              w.wl("_djinni_destroy();")
               w.wl("super.finalize();")
             }
             for (m <- i.methods if !m.static) { // Static methods not in CppProxy

--- a/src/source/JavaGenerator.scala
+++ b/src/source/JavaGenerator.scala
@@ -180,12 +180,12 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
             }
             w.wl
             w.wl("private native void nativeDestroy(long nativeRef);")
-            w.wl("public void _djinni_destroy()").braced {
+            w.wl("public void _djinni_private_destroy()").braced {
               w.wl("boolean destroyed = this.destroyed.getAndSet(true);")
               w.wl("if (!destroyed) nativeDestroy(this.nativeRef);")
             }
             w.wl("protected void finalize() throws java.lang.Throwable").braced {
-              w.wl("_djinni_destroy();")
+              w.wl("_djinni_private_destroy();")
               w.wl("super.finalize();")
             }
             for (m <- i.methods if !m.static) { // Static methods not in CppProxy

--- a/src/source/JavaGenerator.scala
+++ b/src/source/JavaGenerator.scala
@@ -180,12 +180,12 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
             }
             w.wl
             w.wl("private native void nativeDestroy(long nativeRef);")
-            w.wl("public void destroy()").braced {
+            w.wl("public void __destroy()").braced {
               w.wl("boolean destroyed = this.destroyed.getAndSet(true);")
               w.wl("if (!destroyed) nativeDestroy(this.nativeRef);")
             }
             w.wl("protected void finalize() throws java.lang.Throwable").braced {
-              w.wl("destroy();")
+              w.wl("__destroy();")
               w.wl("super.finalize();")
             }
             for (m <- i.methods if !m.static) { // Static methods not in CppProxy

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/Conflict.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/Conflict.java
@@ -25,14 +25,14 @@ public abstract class Conflict {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/Conflict.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/Conflict.java
@@ -25,14 +25,14 @@ public abstract class Conflict {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/Conflict.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/Conflict.java
@@ -25,14 +25,14 @@ public abstract class Conflict {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConflictUser.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConflictUser.java
@@ -26,14 +26,14 @@ public abstract class ConflictUser {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConflictUser.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConflictUser.java
@@ -26,14 +26,14 @@ public abstract class ConflictUser {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConflictUser.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConflictUser.java
@@ -26,14 +26,14 @@ public abstract class ConflictUser {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
@@ -89,14 +89,14 @@ public abstract class ConstantsInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
@@ -89,14 +89,14 @@ public abstract class ConstantsInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
@@ -89,14 +89,14 @@ public abstract class ConstantsInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/CppException.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/CppException.java
@@ -25,14 +25,14 @@ public abstract class CppException {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/CppException.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/CppException.java
@@ -25,14 +25,14 @@ public abstract class CppException {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/CppException.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/CppException.java
@@ -25,14 +25,14 @@ public abstract class CppException {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/EnumUsageInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/EnumUsageInterface.java
@@ -38,14 +38,14 @@ public abstract class EnumUsageInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/EnumUsageInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/EnumUsageInterface.java
@@ -38,14 +38,14 @@ public abstract class EnumUsageInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/EnumUsageInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/EnumUsageInterface.java
@@ -38,14 +38,14 @@ public abstract class EnumUsageInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ExternInterface1.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ExternInterface1.java
@@ -20,14 +20,14 @@ public abstract class ExternInterface1 {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ExternInterface1.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ExternInterface1.java
@@ -20,14 +20,14 @@ public abstract class ExternInterface1 {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ExternInterface1.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ExternInterface1.java
@@ -20,14 +20,14 @@ public abstract class ExternInterface1 {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/FlagRoundtrip.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/FlagRoundtrip.java
@@ -33,14 +33,14 @@ public abstract class FlagRoundtrip {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/FlagRoundtrip.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/FlagRoundtrip.java
@@ -33,14 +33,14 @@ public abstract class FlagRoundtrip {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/FlagRoundtrip.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/FlagRoundtrip.java
@@ -33,14 +33,14 @@ public abstract class FlagRoundtrip {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/InterfaceUsingExtendedRecord.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/InterfaceUsingExtendedRecord.java
@@ -28,14 +28,14 @@ public abstract class InterfaceUsingExtendedRecord {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/InterfaceUsingExtendedRecord.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/InterfaceUsingExtendedRecord.java
@@ -28,14 +28,14 @@ public abstract class InterfaceUsingExtendedRecord {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/InterfaceUsingExtendedRecord.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/InterfaceUsingExtendedRecord.java
@@ -28,14 +28,14 @@ public abstract class InterfaceUsingExtendedRecord {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ListenerCaller.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ListenerCaller.java
@@ -33,14 +33,14 @@ public abstract class ListenerCaller {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ListenerCaller.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ListenerCaller.java
@@ -33,14 +33,14 @@ public abstract class ListenerCaller {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ListenerCaller.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ListenerCaller.java
@@ -33,14 +33,14 @@ public abstract class ListenerCaller {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnOne.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnOne.java
@@ -26,14 +26,14 @@ public abstract class ReturnOne {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnOne.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnOne.java
@@ -26,14 +26,14 @@ public abstract class ReturnOne {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnOne.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnOne.java
@@ -26,14 +26,14 @@ public abstract class ReturnOne {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnTwo.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnTwo.java
@@ -26,14 +26,14 @@ public abstract class ReturnTwo {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnTwo.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnTwo.java
@@ -26,14 +26,14 @@ public abstract class ReturnTwo {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnTwo.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnTwo.java
@@ -26,14 +26,14 @@ public abstract class ReturnTwo {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReverseClientInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReverseClientInterface.java
@@ -32,14 +32,14 @@ public abstract class ReverseClientInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReverseClientInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReverseClientInterface.java
@@ -32,14 +32,14 @@ public abstract class ReverseClientInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReverseClientInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReverseClientInterface.java
@@ -32,14 +32,14 @@ public abstract class ReverseClientInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestDuration.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestDuration.java
@@ -79,14 +79,14 @@ public abstract class TestDuration {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestDuration.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestDuration.java
@@ -79,14 +79,14 @@ public abstract class TestDuration {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestDuration.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestDuration.java
@@ -79,14 +79,14 @@ public abstract class TestDuration {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
@@ -94,14 +94,14 @@ public abstract class TestHelpers {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
@@ -94,14 +94,14 @@ public abstract class TestHelpers {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
@@ -94,14 +94,14 @@ public abstract class TestHelpers {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/UserToken.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/UserToken.java
@@ -23,14 +23,14 @@ public abstract class UserToken {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/UserToken.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/UserToken.java
@@ -23,14 +23,14 @@ public abstract class UserToken {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/UserToken.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/UserToken.java
@@ -23,14 +23,14 @@ public abstract class UserToken {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/UsesSingleLanguageListeners.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/UsesSingleLanguageListeners.java
@@ -34,14 +34,14 @@ public abstract class UsesSingleLanguageListeners {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/UsesSingleLanguageListeners.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/UsesSingleLanguageListeners.java
@@ -34,14 +34,14 @@ public abstract class UsesSingleLanguageListeners {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/UsesSingleLanguageListeners.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/UsesSingleLanguageListeners.java
@@ -34,14 +34,14 @@ public abstract class UsesSingleLanguageListeners {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/VarnameInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/VarnameInterface.java
@@ -31,14 +31,14 @@ public abstract class VarnameInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/VarnameInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/VarnameInterface.java
@@ -31,14 +31,14 @@ public abstract class VarnameInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/VarnameInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/VarnameInterface.java
@@ -31,14 +31,14 @@ public abstract class VarnameInterface {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/WcharTestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/WcharTestHelpers.java
@@ -30,14 +30,14 @@ public abstract class WcharTestHelpers {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void destroy()
+        public void __destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            destroy();
+            __destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/WcharTestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/WcharTestHelpers.java
@@ -30,14 +30,14 @@ public abstract class WcharTestHelpers {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void _djinni_destroy()
+        public void _djinni_private_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            _djinni_destroy();
+            _djinni_private_destroy();
             super.finalize();
         }
     }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/WcharTestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/WcharTestHelpers.java
@@ -30,14 +30,14 @@ public abstract class WcharTestHelpers {
         }
 
         private native void nativeDestroy(long nativeRef);
-        public void __destroy()
+        public void _djinni_destroy()
         {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
         protected void finalize() throws java.lang.Throwable
         {
-            __destroy();
+            _djinni_destroy();
             super.finalize();
         }
     }


### PR DESCRIPTION
Mirror of dropbox djinni#365
This prevents compilation errors when someone creates a djinni interface with their own method named "destroy()".
