### PR TITLE
Mirror of dropbox djinni#357

### DIFF
--- a/src/build.sbt
+++ b/src/build.sbt
@@ -1,6 +1,6 @@
 import com.typesafe.sbt.SbtStartScript
 
-scalaVersion := "2.11.0"
+scalaVersion := "2.11.12"
 
 libraryDependencies ++= Seq(
 	"org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1",

--- a/src/project/build.properties
+++ b/src/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.17


### PR DESCRIPTION
Mirror of dropbox djinni#357
Per http://docs.scala-lang.org/overviews/jdk-compatibility/overview.html, Scala 2.11.12 and sbt 0.13.17 are the minimum versions supporting JDK 9.

Refs #356.
