### PR TITLE
Mirror of dropbox djinni#349

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -106,6 +106,13 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
                 w.wl(s"return std::hash<$underlyingType>()(static_cast<$underlyingType>(type));")
               }
             }
+            w.wl("template <>")
+            w.w(s"class numeric_limits<$fqSelf> : public numeric_limits<$underlyingType>").bracedSemi {
+              w.wl("public:")
+              w.wl("static constexpr bool is_specialized = true;")
+              if(!e.flags) w.wl(s"static constexpr $fqSelf min() noexcept { return $fqSelf::${idCpp.enum(normalEnumOptions(e).head.ident.name)}; }")
+              w.wl(s"static constexpr $fqSelf max() noexcept { return " + (if(e.flags) s"static_cast<$fqSelf>(${normalEnumOptions(e).size})" else s"$fqSelf::${idCpp.enum(normalEnumOptions(e).last.ident.name)}") +"; }")
+            }
           }
         )
       }

--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -91,6 +91,11 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
         w.w(s"constexpr $self operator~($self x) noexcept").braced {
           w.wl(s"return static_cast<$self>(~static_cast<$flagsType>(x));")
         }
+      } else {
+        // Define useful operators for enum
+        w.w(s"constexpr $self operator++($self const& r, int increment) noexcept").braced {
+          w.wl(s"return $self(($underlyingType)r + increment);")
+        }
       }
     },
     w => {

--- a/test-suite/generated-src/cpp/access_flags.hpp
+++ b/test-suite/generated-src/cpp/access_flags.hpp
@@ -52,5 +52,11 @@ struct hash<::testsuite::access_flags> {
         return std::hash<unsigned>()(static_cast<unsigned>(type));
     }
 };
+template <>
+class numeric_limits<::testsuite::access_flags> : public numeric_limits<unsigned> {
+    public:
+    static constexpr bool is_specialized = true;
+    static constexpr ::testsuite::access_flags max() noexcept { return static_cast<::testsuite::access_flags>(9); }
+};
 
 }  // namespace std

--- a/test-suite/generated-src/cpp/color.hpp
+++ b/test-suite/generated-src/cpp/color.hpp
@@ -21,6 +21,9 @@ enum class color : int {
     INDIGO,
     VIOLET,
 };
+constexpr color operator++(color const& r, int increment) noexcept {
+    return color((int)r + increment);
+}
 
 }  // namespace testsuite
 

--- a/test-suite/generated-src/cpp/color.hpp
+++ b/test-suite/generated-src/cpp/color.hpp
@@ -32,5 +32,12 @@ struct hash<::testsuite::color> {
         return std::hash<int>()(static_cast<int>(type));
     }
 };
+template <>
+class numeric_limits<::testsuite::color> : public numeric_limits<int> {
+    public:
+    static constexpr bool is_specialized = true;
+    static constexpr ::testsuite::color min() noexcept { return ::testsuite::color::RED; }
+    static constexpr ::testsuite::color max() noexcept { return ::testsuite::color::VIOLET; }
+};
 
 }  // namespace std

--- a/test-suite/generated-src/cpp/empty_flags.hpp
+++ b/test-suite/generated-src/cpp/empty_flags.hpp
@@ -43,5 +43,11 @@ struct hash<::testsuite::empty_flags> {
         return std::hash<unsigned>()(static_cast<unsigned>(type));
     }
 };
+template <>
+class numeric_limits<::testsuite::empty_flags> : public numeric_limits<unsigned> {
+    public:
+    static constexpr bool is_specialized = true;
+    static constexpr ::testsuite::empty_flags max() noexcept { return static_cast<::testsuite::empty_flags>(0); }
+};
 
 }  // namespace std


### PR DESCRIPTION
Mirror of dropbox djinni#349
This PR allows to query the size of an enum, without polluting the enum with a `Count` entry.
(So switch-case expressions can still be complete)

I tried a lot of different approaches and settled on adding template specializers for `std::numeric_limits`. 

We use it in our codebase to ensure enum<->string maps cover all enumeration cases:

Example use case:
```
#define PDFCAssertMapCoversAllEnumCases(var) PDFCAssert(var.size() == (size_t)std::numeric_limits<decltype(var)::mapped_type>::max() + 1);
```
(This could also be a `static_assert`, needs further changes on our maps though)

I do not know if this is the best approach, there are many very complex enum wrappers around, yet this variant is more minimal, compiles away completely and doesn't modify/pollute the enum itself.

Without specialization, `std::numeric_limits` does not make sense on enum types and returns 0. It's very unlikely that any code breaks because these specializations are added.

The second addition allows to call `++` on an enum to increment over it in a loop. Since we add a few such operators for `flags`, this seemed appropriate.

Tests passed locally:

```
Test Suite 'All tests' passed at 2018-01-11 23:22:01.121.
	 Executed 50 tests, with 0 failures (0 unexpected) in 0.037 (0.094) seconds
** TEST SUCCEEDED **

     [java] .........
     [java] Time: 0.133
     [java]
     [java] OK (38 tests)
     [java]

BUILD SUCCESSFUL
Total time: 32 seconds
```
