### PR TITLE
Mirror of dropbox djinni#348

### DIFF
--- a/support-lib/objc/DJIError.h
+++ b/support-lib/objc/DJIError.h
@@ -30,6 +30,6 @@ namespace djinni {
     ::djinni::throwUnimplemented(__PRETTY_FUNCTION__, msg);
 
 #define DJINNI_TRANSLATE_EXCEPTIONS() \
-    catch (const std::exception & e) { \
+    catch (__unused const std::exception & e) { \
         ::djinni::throwNSExceptionFromCurrent(__PRETTY_FUNCTION__); \
     }

--- a/support-lib/objc/DJIMarshal+Private.h
+++ b/support-lib/objc/DJIMarshal+Private.h
@@ -29,7 +29,7 @@ struct Bool {
 
     struct Boxed {
         using ObjcType = NSNumber*;
-        static CppType toCpp(ObjcType x) noexcept { assert(x); return Bool::toCpp([x boolValue]); }
+        static CppType toCpp(ObjcType x) noexcept { assert(x != nil); return Bool::toCpp([x boolValue]); }
         static ObjcType fromCpp(CppType x) noexcept { return [NSNumber numberWithBool:Bool::fromCpp(x)]; }
     };
 };
@@ -44,7 +44,7 @@ struct Primitive {
 
     struct Boxed {
         using ObjcType = NSNumber*;
-        static CppType toCpp(ObjcType x) noexcept { assert(x); return static_cast<CppType>(Self::unbox(x)); }
+        static CppType toCpp(ObjcType x) noexcept { assert(x != nil); return static_cast<CppType>(Self::unbox(x)); }
         static ObjcType fromCpp(CppType x) noexcept { return Self::box(x); }
     };
 };
@@ -233,7 +233,7 @@ public:
     using Boxed = Optional;
 
     static CppType toCpp(ObjcType obj) {
-        if (obj) {
+        if (obj != nil) {
             return T::Boxed::toCpp(obj);
         } else {
             return CppType();


### PR DESCRIPTION
Mirror of dropbox djinni#348
This fixes an Analyzer warning that shows up in Xcode 9:
https://github.com/llvm-mirror/clang/blob/master/test/Analysis/number-object-conversion.cpp

```
34:20: warning: Converting a pointer value of type 'ObjcType' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
            assert(x);
```

Also fixes an optional warning:

The `__unused` on the exception is needed when `-Wunused-exception-parameter` is enabled.

```
warning: unused exception parameter 'e' [-Wunused-exception-parameter]
        DJINNI_TRANSLATE_EXCEPTIONS()
        ^
```

Both are trivial changes that do not change functionality.
Thanks for making Djinni! We from PSPDFKit love it!
