### PR TITLE
Mirror of dropbox djinni#255

### DIFF
--- a/example/generated-src/objc/TXSSortItems+Private.mm
+++ b/example/generated-src/objc/TXSSortItems+Private.mm
@@ -13,6 +13,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface TXSSortItems ()
 

--- a/example/objc/TextSort.xcodeproj/project.pbxproj
+++ b/example/objc/TextSort.xcodeproj/project.pbxproj
@@ -150,7 +150,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = TXS;
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Dropbox, Inc.";
 			};
 			buildConfigurationList = 65834DD819AC599E0061AD3F /* Build configuration list for PBXProject "TextSort" */;
@@ -236,6 +236,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -250,7 +251,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -284,7 +284,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../support-lib/objc $(SRCROOT)/../generated-src/objc";
@@ -301,6 +300,7 @@
 				GCC_PREFIX_HEADER = "TextSort/TextSort-Prefix.pch";
 				INFOPLIST_FILE = "TextSort/TextSort-Info.plist";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "Dropbox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
@@ -316,6 +316,7 @@
 				GCC_PREFIX_HEADER = "TextSort/TextSort-Prefix.pch";
 				INFOPLIST_FILE = "TextSort/TextSort-Info.plist";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "Dropbox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;

--- a/example/objc/TextSort.xcodeproj/xcshareddata/xcschemes/TextSort.xcscheme
+++ b/example/objc/TextSort.xcodeproj/xcshareddata/xcschemes/TextSort.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,17 +38,21 @@
             ReferencedContainer = "container:TextSort.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "65834DDC19AC599E0061AD3F"
@@ -61,12 +65,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "65834DDC19AC599E0061AD3F"

--- a/example/objc/TextSort/TextSort-Info.plist
+++ b/example/objc/TextSort/TextSort-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>Dropbox.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/src/source/ObjcppGenerator.scala
+++ b/src/source/ObjcppGenerator.scala
@@ -138,6 +138,10 @@ class ObjcppGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
       val objcSelf = if (i.ext.objc && i.ext.cpp) self + "CppProxy" else self
 
       if (i.ext.cpp) {
+		// Disable warnings in Clang about directly accessing the ivars of an object
+		w.wl("#if __clang__")
+        w.wl("#pragma clang diagnostic ignored \"-Wdirect-ivar-access\"")
+		w.wl("#endif")
         w.wl
         if (i.ext.objc)
           w.wl(s"@interface $objcSelf : NSObject<$self>")

--- a/test-suite/generated-src/objc/DBConflict+Private.mm
+++ b/test-suite/generated-src/objc/DBConflict+Private.mm
@@ -9,6 +9,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBConflict ()
 

--- a/test-suite/generated-src/objc/DBConflictUser+Private.mm
+++ b/test-suite/generated-src/objc/DBConflictUser+Private.mm
@@ -11,6 +11,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBConflictUser ()
 

--- a/test-suite/generated-src/objc/DBConstantsInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBConstantsInterface+Private.mm
@@ -11,6 +11,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBConstantsInterface ()
 

--- a/test-suite/generated-src/objc/DBCppException+Private.mm
+++ b/test-suite/generated-src/objc/DBCppException+Private.mm
@@ -11,6 +11,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBCppException ()
 

--- a/test-suite/generated-src/objc/DBExternInterface1+Private.mm
+++ b/test-suite/generated-src/objc/DBExternInterface1+Private.mm
@@ -11,6 +11,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBExternInterface1 ()
 

--- a/test-suite/generated-src/objc/DBListenerCaller+Private.mm
+++ b/test-suite/generated-src/objc/DBListenerCaller+Private.mm
@@ -12,6 +12,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBListenerCaller ()
 

--- a/test-suite/generated-src/objc/DBReturnOne+Private.mm
+++ b/test-suite/generated-src/objc/DBReturnOne+Private.mm
@@ -11,6 +11,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBReturnOne ()
 

--- a/test-suite/generated-src/objc/DBReturnTwo+Private.mm
+++ b/test-suite/generated-src/objc/DBReturnTwo+Private.mm
@@ -11,6 +11,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBReturnTwo ()
 

--- a/test-suite/generated-src/objc/DBReverseClientInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBReverseClientInterface+Private.mm
@@ -11,6 +11,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBReverseClientInterface ()
 

--- a/test-suite/generated-src/objc/DBTestDuration+Private.mm
+++ b/test-suite/generated-src/objc/DBTestDuration+Private.mm
@@ -11,6 +11,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBTestDuration ()
 

--- a/test-suite/generated-src/objc/DBTestHelpers+Private.mm
+++ b/test-suite/generated-src/objc/DBTestHelpers+Private.mm
@@ -17,6 +17,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBTestHelpers ()
 

--- a/test-suite/generated-src/objc/DBUserToken+Private.mm
+++ b/test-suite/generated-src/objc/DBUserToken+Private.mm
@@ -11,6 +11,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBUserTokenCppProxy : NSObject<DBUserToken>
 

--- a/test-suite/generated-src/objc/DBUsesSingleLanguageListeners+Private.mm
+++ b/test-suite/generated-src/objc/DBUsesSingleLanguageListeners+Private.mm
@@ -12,6 +12,7 @@
 #include <utility>
 
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
 @interface DBUsesSingleLanguageListenersCppProxy : NSObject<DBUsesSingleLanguageListeners>
 


### PR DESCRIPTION
Mirror of dropbox djinni#255
We just added djinni generated files to an existing iOS project and it blessed us with about 200 new warnings. This adds `#pragma clang diagnostic ignored "-Wdirect-ivar-access"` to `.mm` files unless someone knows how to generate equally efficient code that doesn't trigger it.

